### PR TITLE
(maint) Build razor-server using puppetlabs repo

### DIFF
--- a/configs/components/razor-server.json
+++ b/configs/components/razor-server.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/melissa/razor-server.git", "ref": "origin/maint/master/change-paths"}
+{"url": "git://github.com/puppetlabs/razor-server.git", "ref": "origin/master"}


### PR DESCRIPTION
Prior to this, razor-vanagon was pulling the razor-server code from a
fork rather than the upstream repository. This was because the required
changes to that repo had yet to be merged in. Now that those changes
have been merged in, we need to switch over to the main source
repository.