### PR TITLE
(maint) Add fakeroot to ubuntu 14.04

### DIFF
--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -5,7 +5,7 @@ platform "ubuntu-14.04-amd64" do |plat|
   plat.codename "trusty"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/debian/pl-build-tools-release-trusty.deb"
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot"
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1404-x86_64"
 end


### PR DESCRIPTION
There were recent changes merged to the Ubuntu 14.04 that removed
fakeroot for some strange reason. It looks like this was the last
template that still provided fakeroot as it is a buildtime dependency
for all other platforms. This commit adds fakeroot as a part of the
  build environment setup to enable green builds.