### PR TITLE
(maint) Add message to get razor-admin on path

### DIFF
--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -82,7 +82,7 @@ component "razor-server" do |pkg, settings, platform|
       "/bin/chown -R razor:razor #{settings[:data_root]}/repo || :",
       "/bin/chown -R razor:razor #{settings[:logdir]} || :",
       "/bin/chown -R razor:razor #{settings[:rundir]} || :",
-      "source /etc/profile.d/razorserver.sh",
+      "echo 'The razor-admin binary has been moved to /opt/puppetlabs/bin and is not currently on the path. To access it, log out and log back in or run `source /etc/profile.d/razorserver.sh`'"
     ]
 
   pkg.add_postinstall_action ['install'],


### PR DESCRIPTION
We have moved the location of razor-admin and are no longer linking the
binary into system space. We have added a file to profile.d to add
/opt/puppetlabs/bin to path in order to make razor-admin available.
However, we cannot source this file in the postinst packaging scripts.
To work around this, this commit adds in output warning the user that
the location of razor-admin has changed and noting two ways the user can
make the binary available for use. This is only directly after
installation. All future logins will have /opt/puppetlabs/bin on the
path and razor-admin available for use.

The only reason we can't just run `source /etc/profile.d/razorserver.sh`
in the postinst packaging scripts is that those scripts are run in
subshells. Any environment changes made there do not persist to the
current environment.