### PR TITLE
(RE-8457) Update to ship to puppet5

### DIFF
--- a/configs/projects/razor-server.rb
+++ b/configs/projects/razor-server.rb
@@ -22,7 +22,7 @@ server taking possession of ESX systems).
   proj.license "See components"
   proj.vendor "Puppet Labs <info@puppetlabs.com>"
   proj.homepage "https://www.puppet.com"
-  proj.target_repo "PC1"
+  proj.target_repo "puppet5"
   proj.noarch
 
   proj.conflicts "razor-torquebox"

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,10 +1,11 @@
 ---
 project: 'razor-server'
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 gpg_key: '7F438280EF8D349F'
+gpg_nonfinal_key: 'B8F999C007BB6C57'
 sign_tar: FALSE
 vanagon_project: TRUE
-apt_repo_name: 'PC1'
-yum_repo_name: 'PC1'
+repo_name: 'puppet5'
+nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE


### PR DESCRIPTION
This commit updates razor-server to ship to the new puppet5 repos. This
change also includes settings for our nonfinal repos. This means that we
can ship development/beta/nightly builds to our nightly repos.

When razor-server ships to the puppet5 repos, we need to ensure what we
ship works with the puppet5 ecosystem.