### PR TITLE
(RE-9648) Migrate vanagon projects to use buildsources in Artifactory

### DIFF
--- a/configs/components/razor-torquebox.rb
+++ b/configs/components/razor-torquebox.rb
@@ -1,7 +1,7 @@
 component "razor-torquebox" do |pkg, settings, platform|
   pkg.version "3.1.2"
   pkg.md5sum "dd79cb07d20b3135c3651b7a9c0cb40d"
-  pkg.url "http://buildsources.delivery.puppetlabs.net/torquebox-#{pkg.get_version}.tar.gz"
+  pkg.url "#{settings[:buildsources_url]}/torquebox-#{pkg.get_version}.tar.gz"
   pkg.add_source "file://resources/files/razor-torquebox.sh", sum: 'b0c34243002a691ee2179e749de59ae4'
   pkg.add_source "file://resources/files/standalone.xml", sum: '6b0a5e1a7fe63407de03a8ee1bba43f8'
 

--- a/configs/projects/razor-server.rb
+++ b/configs/projects/razor-server.rb
@@ -40,6 +40,9 @@ server taking possession of ESX systems).
   proj.setting(:server_bindir, "/opt/puppetlabs/server/bin")
   proj.setting(:agent_bindir, "/opt/puppetlabs/bin")
 
+  proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/artifactory")
+  proj.setting(:buildsources_url, "#{artifactory_url}/generic/buildsources")
+
   proj.user("razor", group: "razor", shell: '/bin/bash', is_system: true, homedir: "#{proj.install_root}/var/razor")
 
   proj.directory proj.prefix


### PR DESCRIPTION
This commit adds `artifactory_url` and `buildsources_url` settings and replaces buildsources.delivery.puppetlabs.net with Artifactory.