### PR TITLE
(maint) Bump torquebox version to 3.2.0

### DIFF
--- a/configs/components/razor-torquebox.rb
+++ b/configs/components/razor-torquebox.rb
@@ -1,6 +1,6 @@
 component "razor-torquebox" do |pkg, settings, platform|
-  pkg.version "3.1.2"
-  pkg.md5sum "dd79cb07d20b3135c3651b7a9c0cb40d"
+  pkg.version "3.2.0"
+  pkg.md5sum "271f84fec822ed7222cb09adfa75b256"
   pkg.url "#{settings[:buildsources_url]}/torquebox-#{pkg.get_version}.tar.gz"
   pkg.add_source "file://resources/files/razor-torquebox.sh", sum: 'b0c34243002a691ee2179e749de59ae4'
   pkg.add_source "file://resources/files/standalone.xml", sum: '6b0a5e1a7fe63407de03a8ee1bba43f8'


### PR DESCRIPTION
This commit bumps the torquebox version to 3.2.0. This change was already made in the razor-server component, since this version of torquebox has the necessary jruby version, but is also needed to build.