### PR TITLE
(maint) Add rpm_targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,3 +9,4 @@ vanagon_project: TRUE
 repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE
+rpm_targets: 'el-6-x86_64 el-7-x86_64'


### PR DESCRIPTION
This commit adds `rpm_targets` to build_defaults.yaml so that packaging knows which platforms to sign for PE.