### PR TITLE
(maint) Add yum_ and apt_repo_name

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -6,6 +6,8 @@ gpg_key: '7F438280EF8D349F'
 gpg_nonfinal_key: 'B8F999C007BB6C57'
 sign_tar: FALSE
 vanagon_project: TRUE
+yum_repo_name: 'puppet5'
+apt_repo_name: 'puppet5'
 repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE


### PR DESCRIPTION
This commit adds `yum_repo_name` and `apt_repo_name` to build_defaults.
Since PE still uses packaging#master, these params are needed (instead of
`repo_name`) so that we can construct the artifact path for promotion.