### PR TITLE
(maint) Add (empty) deb_targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -12,3 +12,4 @@ repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE
 rpm_targets: 'el-6-x86_64 el-7-x86_64'
+deb_targets: ''


### PR DESCRIPTION
This commit adds a deb_targets key to build_defaults.yaml. When promoting to PE,
the signing task splits on deb (and rpm) targets, so even though we don't ship
pe-razor-server for debian, we need to include some value for the key so that
we don't try to split on nil.