### PR TITLE
(maint) Install sysconfig under appropriate service name

### DIFF
--- a/configs/components/razor-server.json
+++ b/configs/components/razor-server.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/razor-server.git", "ref": "1.8.0"}
+{"url": "git://github.com/puppetlabs/razor-server.git", "ref": "1.8.1"}

--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -50,7 +50,7 @@ component "razor-server" do |pkg, settings, platform|
   else
     fail "need to know where to put service files"
   end
-  pkg.install_configfile "ext/razor-server.sysconfig", "/etc/sysconfig/razor-server"
+  pkg.install_configfile "ext/razor-server.sysconfig", "/etc/sysconfig/#{service_name}"
   pkg.install_configfile "config.yaml.sample", "#{settings[:configdir]}/config.yaml"
   pkg.install_configfile "shiro.ini", "#{settings[:sysconfdir]}/shiro.ini"
 


### PR DESCRIPTION
This PR changes the installation of the razor-server sysconfig to use
the `service_name` variable, which is 'pe-razor-server' if we're building for
PE, and otherwise 'razor-server'.

This PR also bumps the razor-server version to 1.8.1 for release.