### PR TITLE
(maint) Change service file to look for pe-razor-server sysconfig

### DIFF
--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -80,6 +80,8 @@ component "razor-server" do |pkg, settings, platform|
       # Change users to pe-razor
       install_commands.push("sed -i 's/USER=razor/USER=pe-razor/g' #{settings[:prefix]}/razor-server.env")
       install_commands.push("sed -i 's/User=razor/User=pe-razor/g' #{platform.servicedir}/#{service_name}.service")
+      # Change sysconfig environment file to pe-razor-server
+      install_commands.push("sed -i 's/razor-server$$/pe-razor-server/g' #{platform.servicedir}/#{service_name}.service")
     when "sysv"
       # Add JAVA to razor-server.init so it can find pe-java correctly
       install_commands.push("sed -i '/^export LANG$$/ a export JAVA=#{settings[:server_bindir]}/java' #{platform.servicedir}/#{service_name}")


### PR DESCRIPTION
This commit adds an install command when building pe-razor-server to change the
path of the sysconfig environment file from /etc/sysconfig/razor-server to
/etc/sysconfig/pe-razor-server.