### PR TITLE
(RAZOR-1081) Ensure scriptlets don't fail

### DIFF
--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -106,8 +106,8 @@ component "razor-server" do |pkg, settings, platform|
   # On upgrade, check to see if these files exist and copy them out of the way to preserve their contents
   pkg.add_preinstall_action ['upgrade'],
     [
-      "[[ -e #{settings[:configdir]}/config.yaml ]] && mkdir -p /tmp/.razor-server.upgrade && cp #{settings[:configdir]}/config.yaml /tmp/.razor-server.upgrade/config.yaml",
-      "[[ -e #{settings[:sysconfdir]}/shiro.ini ]] && mkdir -p /tmp/.razor-server.upgrade && cp #{settings[:sysconfdir]}/shiro.ini /tmp/.razor-server.upgrade/shiro.ini",
+      "[[ -e #{settings[:configdir]}/config.yaml ]] && mkdir -p /tmp/.razor-server.upgrade && cp #{settings[:configdir]}/config.yaml /tmp/.razor-server.upgrade/config.yaml || :",
+      "[[ -e #{settings[:sysconfdir]}/shiro.ini ]] && mkdir -p /tmp/.razor-server.upgrade && cp #{settings[:sysconfdir]}/shiro.ini /tmp/.razor-server.upgrade/shiro.ini || :",
     ]
 
   pkg.add_postinstall_action ['install', 'upgrade'],
@@ -127,23 +127,23 @@ component "razor-server" do |pkg, settings, platform|
 
   pkg.add_postinstall_action ['upgrade'],
     [
-      "[[ -e /tmp/.razor-server.upgrade/config.yaml ]] && mv /tmp/.razor-server.upgrade/config.yaml #{settings[:configdir]}/config.yaml",
-      "[[ -e /tmp/.razor-server.upgrade/shiro.ini ]] && mv /tmp/.razor-server.upgrade/shiro.ini #{settings[:sysconfdir]}/shiro.ini",
-      "[[ -e /tmp/.razor-server.upgrade ]] && rm -rf /tmp/.razor-server.upgrade",
+      "[[ -e /tmp/.razor-server.upgrade/config.yaml ]] && mv /tmp/.razor-server.upgrade/config.yaml #{settings[:configdir]}/config.yaml || :",
+      "[[ -e /tmp/.razor-server.upgrade/shiro.ini ]] && mv /tmp/.razor-server.upgrade/shiro.ini #{settings[:sysconfdir]}/shiro.ini || :",
+      "[[ -e /tmp/.razor-server.upgrade ]] && rm -rf /tmp/.razor-server.upgrade || :",
 
       # we need making sure the old config files are removed from the file
       # system. If they were already there, they were moved to the new location
       # and should be removed completely from the old location. This happens
       # after we've ensured the old files are available in the new location
-      "[[ -e /etc/razor/config.yaml ]] && rm /etc/razor/config.yaml",
-      "[[ -e /etc/razor/shiro.ini ]] && rm /etc/razor/shiro.ini",
+      "[[ -e /etc/razor/config.yaml ]] && rm /etc/razor/config.yaml || :",
+      "[[ -e /etc/razor/shiro.ini ]] && rm /etc/razor/shiro.ini || :",
 
       # we have to chown the old repo-store location in case the user is still
       # using it. The debian packaging removes the razor user for some reason
       # and this directory loses it's permissions. Since we're not forcing the
       # user to migrate to the new repo store location, we need to make sure
       # the razor user still has access to this directory.
-      "[[ -e /var/lib/razor/repo-store ]] && /bin/chown -R #{settings[:razor_user]}:#{settings[:razor_user]} /var/lib/razor/repo-store",
+      "[[ -e /var/lib/razor/repo-store ]] && /bin/chown -R #{settings[:razor_user]}:#{settings[:razor_user]} /var/lib/razor/repo-store || :",
     ]
 
   pkg.add_preremove_action ['upgrade', 'removal'],


### PR DESCRIPTION
This commit adds `|| :` to several of the pre-/post-(un)install actions to
ensure that package installation still occurs if these actions (moving possibly
existing configs around, e.g.) fail.