### PR TITLE
(maint) Allow `refs/tags/` in component configs

### DIFF
--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -61,7 +61,7 @@ component "razor-server" do |pkg, settings, platform|
       "rm -rf .bundle/install.log",
       "rm -rf vendor/bundle/jruby/1.9/cache",
       "#{jruby} bundle config PATH #{settings[:prefix]}/vendor/bundle",
-      "sed -i -- 's/version = \"DEVELOPMENT\"/version = \"#{@component.options[:ref]}\"/g' lib/razor/version.rb"
+      "sed -i -- 's/version = \"DEVELOPMENT\"/version = \"#{@component.options[:ref].split('/').pop}\"/g' lib/razor/version.rb"
     ]
   end
 


### PR DESCRIPTION
Previously, the `ref` for the razor-server component needed to
be just the version number. Since some of our packaging sets
to `refs/tags/<value>`, we should handle that too.

Waiting to merge until upstream PE is in a release branch.