### PR TITLE
(PE-27189) Use pe-java-razor instead of pe-java

### DIFF
--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -28,8 +28,8 @@ component "razor-server" do |pkg, settings, platform|
     java_home = "JAVA_HOME='/usr/lib/jvm/java-8-openjdk-#{platform.architecture}'"
   end
   if settings[:pe_package]
-    java_build_requires = 'pe-java'
-    java_requires = 'pe-java'
+    java_build_requires = 'pe-java-razor'
+    java_requires = 'pe-java-razor'
     java_home = "JAVA_HOME='/opt/puppetlabs/server/apps/java/lib/jvm/java/jre'"
     service_name = 'pe-razor-server'
   end


### PR DESCRIPTION
To separate razor's java from PE's, this tells the pe-razor-server package to use the new pe-java-razor package instead.