### PR TITLE
(PE-27189) Change default for repo to 2019.3

### DIFF
--- a/configs/projects/pe-razor-server.rb
+++ b/configs/projects/pe-razor-server.rb
@@ -7,7 +7,7 @@ project 'pe-razor-server' do |proj|
 
   proj.setting(:pe_package, true)
   proj.setting(:razor_user, 'pe-razor')
-  proj.setting(:pe_version, ENV['PE_VER'] || '2018.1')
+  proj.setting(:pe_version, ENV['PE_VER'] || '2019.3')
   platform.add_build_repository "http://enterprise.delivery.puppetlabs.net/#{proj.pe_version}/repos/#{platform.name}/#{platform.name}.repo"
 
   proj.instance_eval File.read('configs/projects/razor-server-shared.rb')


### PR DESCRIPTION
This was pointing to 2018.1 by default for the path to find the repo on enterprise.delivery.puppetlabs.net, which is not going to contain the pe-java-razor package. This changes the default to 2019.3.