### PR TITLE
(SEC-166) Dust off razor packaging to get a security update out

### DIFF
--- a/configs/components/razor-server.rb
+++ b/configs/components/razor-server.rb
@@ -28,8 +28,8 @@ component "razor-server" do |pkg, settings, platform|
     java_home = "JAVA_HOME='/usr/lib/jvm/java-8-openjdk-#{platform.architecture}'"
   end
   if settings[:pe_package]
-    java_build_requires = 'pe-java-razor'
-    java_requires = 'pe-java-razor'
+    java_build_requires = 'pe-java'
+    java_requires = 'pe-java'
     java_home = "JAVA_HOME='/opt/puppetlabs/server/apps/java/lib/jvm/java/jre'"
     service_name = 'pe-razor-server'
   end

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -2,8 +2,9 @@ platform "el-6-x86_64" do |plat|
   plat.servicedir "/etc/rc.d/init.d"
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
-
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
+  plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "centos-6-x86_64"
 end

--- a/configs/projects/pe-razor-server.rb
+++ b/configs/projects/pe-razor-server.rb
@@ -7,8 +7,17 @@ project 'pe-razor-server' do |proj|
 
   proj.setting(:pe_package, true)
   proj.setting(:razor_user, 'pe-razor')
-  proj.setting(:pe_version, ENV['PE_VER'] || '2019.3')
-  platform.add_build_repository "http://enterprise.delivery.puppetlabs.net/#{proj.pe_version}/repos/#{platform.name}/#{platform.name}.repo"
+  proj.setting(:pe_version, ENV['PE_VER'] || '2018.1')
+
+  artifactory_url = 'https://artifactory.delivery.puppetlabs.net/artifactory'
+
+  if platform.is_rpm?
+    platform.add_build_repository "#{artifactory_url}/rpm_enterprise__local/#{settings[:pe_version]}/repos/#{platform.name}/#{platform.name}.repo"
+  end
+
+  if platform.is_deb?
+    platform.add_build_repository "#{artifactory_url}/debian_enterprise__local/#{settings[:pe_version]}/repos/#{platform.name}/#{platform.name}.list"
+  end
 
   proj.instance_eval File.read('configs/projects/razor-server-shared.rb')
 


### PR DESCRIPTION
This commit updates the razor vanagon project to look for packages at artifactory. It also updates razor to install pe-java instead of pe-razor-java which was a band-aid to prevent java 11 incompatability which is not an issue in irving. NOTE: given we only need to ship this for irving and there is only a single streem for razor this is acceptable. This is only safe because we are no longer shipping razor with modern PE.