### PR TITLE
(maint) Promote razor-server tag with security fix to vanagon

### DIFF
--- a/configs/components/razor-server.json
+++ b/configs/components/razor-server.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/razor-server.git","ref":"6a643dfd747b16b472759dfbc2d37333f6767dee"}
+{"url":"git://github.com/puppetlabs/razor-server.git","ref":"1.9.9"}


### PR DESCRIPTION
This commit updates the ref for razor-vanagon from the sha including the security fixes to the tag that snapshots that sha.